### PR TITLE
Explicit require numpy 1.15.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 install_requires=[
    'gdspy>=1.3.1',
-   'numpy==1.15.4',  # note: 1.16.0 exists, but there is a name change that breaks scikit-image
+   'numpy<=1.15.4',  # note: 1.16.0 exists, but there is a name change that breaks scikit-image
    'matplotlib',
    'pyyaml',
    'scikit-image>=0.11',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 install_requires=[
    'gdspy>=1.3.1',
-   'numpy',
+   'numpy==1.15.4',  # note: 1.16.0 exists, but there is a name change that breaks scikit-image
    'matplotlib',
    'pyyaml',
    'scikit-image>=0.11',


### PR DESCRIPTION
numpy 1.16.0 was released two days ago. It renamed a function called `_validate_lengths` which scikit-image expects.

### Anybody who has pip --upgraded numpy in the past two days will not be able to use phidl. Can't fix that.

This patch makes it so fresh installs or --upgrades of phidl will downgrade your numpy to the latest working version.

The scikit people are working on it:
https://github.com/scikit-image/scikit-image/issues/3649