### PR TITLE
remove_layers no longer removes DeviceReferences

### DIFF
--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -680,6 +680,7 @@ class Device(gdspy.Cell, _GeometryHelper):
                 if isinstance(e, DeviceReference):
                      new_elements.append(e)
             D.elements = new_elements
+
             if include_labels == True:
                 new_labels = []
                 for l in D.labels:

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -677,8 +677,9 @@ class Device(gdspy.Cell, _GeometryHelper):
                         e.layers = new_layers
                         e.datatypes = new_datatypes
                         new_elements.append(e)
+                if isinstance(e, DeviceReference):
+                     new_elements.append(e)
             D.elements = new_elements
-
             if include_labels == True:
                 new_labels = []
                 for l in D.labels:


### PR DESCRIPTION
## Fix in `Device.remove_layers`
Before, it was also removing all `DeviceReferences`.
