### PR TITLE
1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,4 @@ target/
 *.bat
 *.lyp
 *.oas
-*.ipynb
 *.svg

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,9 @@ python:
 #       dist: xenial
 #       sudo: required
 
-before_install:
-    # Tricks to avoid matplotlib error about X11:
-    # 'no display name and no $DISPLAY environment variable'
-    # http://docs.travis-ci.com/user/gui-and-headless-browsers/#Starting-a-Web-Server
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
+services:
+  - xvfb
+
 
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # matrix:
 #   include:

--- a/README.md
+++ b/README.md
@@ -81,10 +81,13 @@ You can also do things like create a backing fill to make sure the resist develo
 ## 1.1.0 (July 3, 2019)
 
 ### New features
-- Added CellArray support, use the `D.add_array()` function (see the [tutorial](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py) for more details)
+- New online notebook to try out PHIDL!  Try now in an interactive online notebook: [Link](https://mybinder.org/v2/gh/amccaugh/phidl/jupyter-notebook2?filepath=phidl_tutorial_example.ipynb)
+- Added full CellArray support, use the `D.add_array()` function (see the [tutorial](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py) for more details)
 - Allow plotting of `DeviceReference`s directly in `quickplot`
 
 ### Changes
+- Added `connector_symmetric` argument to `pg.snspd_expanded()`
+
 
 ### Bugfixes
 - Bounding box cache speed improvement

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ You can also do things like create a backing fill to make sure the resist develo
 
 # Changelog
 
+## 1.1.0 (July 3, 2019)
+
+### New features
+- Added CellArray support, use the `D.add_array()` function (see the [tutorial](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py) for more details)
+- Allow plotting of `DeviceReference`s directly in `quickplot`
+
+### Changes
+
+### Bugfixes
+- Bounding box cache speed improvement
+
+
 ## 1.0.3 (May 23, 2019)
 - Maintenance release to work with `gdspy 1.4`
 - Removal of `scipy` from strict installation requirements

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 PHotonic and Integrated Device Layout - GDS CAD layout and geometry creation for photonic and superconducting circuits
 
 - [Installation / requirements](#installation--requirements)
+- [Tutorial + examples](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py#L35) (Try now in an interactive notebook: [Link](https://mybinder.org/v2/gh/amccaugh/phidl/jupyter-notebook2?filepath=phidl_tutorial_example.ipynb))
 - [About PHIDL](#about-phidl)
 - [Changelog](#changelog)
-- [Tutorial + examples](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py#L35)
 
 # Installation / requirements
 - Install or upgrade with `pip install -U phidl`

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: example-environment
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  - psutil
+  - toolz
+  - matplotlib
+  - dill
+  - pandas
+  - partd
+  - bokeh
+  - dask

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - numpy
-  - psutil
-  - toolz
   - matplotlib
-  - dill
-  - pandas
-  - partd
-  - bokeh
-  - dask
+  - scipy
+  - phidl

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,0 @@
-name: example-environment
-channels:
-  - conda-forge
-dependencies:
-  - numpy
-  - matplotlib
-  - scipy
-  - phidl

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -1,8 +1,6 @@
 #==============================================================================
 # Major TODO
 #==============================================================================
-# Add CellArray support for moving/rotating/etc (also add to import_gds)
-# Remove devicereference .parent._bb_is_valid
 # Replace move command with _input2coordinate
 
 #==============================================================================
@@ -10,7 +8,6 @@
 #==============================================================================
 # geometry: add packer, basic_wire
 # Let both References/Arrays/Polygons to be assigned as D['waveguide'] = D << WG
-# PHIDL fix quickplot "AttributeError: 'DeviceReference' object has no attribute 'aliases'"
 
 #==============================================================================
 # Imports
@@ -30,7 +27,7 @@ import warnings
 import hashlib
 
 
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 
 

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -2,6 +2,8 @@
 # Major TODO
 #==============================================================================
 # Add CellArray support for moving/rotating/etc (also add to import_gds)
+# Remove devicereference .parent._bb_is_valid
+# Replace move command with _input2coordinate
 
 #==============================================================================
 # Minor TODO
@@ -66,6 +68,19 @@ def _reflect_points(points, p1 = (0,0), p2 = (1,0)):
 
 def _is_iterable(items):
     return isinstance(items, (list, tuple, set, np.ndarray))
+
+def _parse_coordinate(c, ports = {}):
+    """ Translates various inputs (lists, tuples, Ports, ) to an (x,y) coordinate """
+    if isinstance(c, Port):
+        return c.midpoint
+    elif np.array(c).size == 2:
+        return c
+    elif c in ports: 
+        return ports[c].midpoint
+    else:
+        return None
+
+
 
 
 def reset():
@@ -497,15 +512,15 @@ class Device(gdspy.Cell, _GeometryHelper):
         if bbox is None:  bbox = ((0,0),(0,0))
         return np.array(bbox)
 
-    def add_ref(self, D, alias = None):
+    def add_ref(self, device, alias = None):
         """ Takes a Device and adds it as a DeviceReference to the current
         Device.  """
-        if _is_iterable(D):
-            return [self.add_ref(E) for E in D]
-        if not isinstance(D, Device):
+        if _is_iterable(device):
+            return [self.add_ref(E) for E in device]
+        if not isinstance(device, Device):
             raise TypeError("""[PHIDL] add_ref() was passed something that
             was not a Device object. """)
-        d = DeviceReference(D)   # Create a DeviceReference (CellReference)
+        d = DeviceReference(device)   # Create a DeviceReference (CellReference)
         self.add(d)             # Add DeviceReference (CellReference) to Device (Cell)
 
         if alias is not None:
@@ -552,6 +567,17 @@ class Device(gdspy.Cell, _GeometryHelper):
         return polygon
 
 
+    def add_array(self, device, columns = 2, rows = 2, spacing = (100,100), alias = None):
+        if not isinstance(device, Device):
+            raise TypeError("""[PHIDL] add_array() was passed something that
+            was not a Device object. """)
+        a = CellArray(device = device, columns = columns, rows = rows, spacing = spacing)
+        self.add(a)             # Add DeviceReference (CellReference) to Device (Cell)
+        if alias is not None:
+            self.aliases[alias] = a
+        return a                # Return the CellArray
+
+
     def add_port(self, name = None, midpoint = (0,0), width = 1, orientation = 45, port = None):
         """ Can be called to copy an existing port like add_port(port = existing_port) or
         to create a new port add_port(myname, mymidpoint, mywidth, myorientation).
@@ -573,17 +599,6 @@ class Device(gdspy.Cell, _GeometryHelper):
             raise ValueError('[DEVICE] add_port() error: Port name "%s" already exists in this Device (name "%s", uid %s)' % (p.name, self._internal_name, self.uid))
         self.ports[p.name] = p
         return p
-
-    def add_array(self, device, start = (0,0), spacing = (10,0), num_devices = 6, config = None, **kwargs):
-         # Check if ``device`` is actually a device-making function
-        if callable(device):    d = make_device(fun = device, config = config, **kwargs)
-        else:                   d = device
-        references = []
-        for n in range(num_devices):
-            sd = self.add_ref(d)
-            sd.move(destination = np.array(spacing)*n, origin = -np.array(start))
-            references.append(sd)
-        return references
 
 
     def label(self, text = 'hello', position = (0,0), magnification = None, rotation = None, layer = 255):
@@ -1078,3 +1093,91 @@ class DeviceReference(gdspy.CellReference, _GeometryHelper):
         return self
 
 
+
+
+class CellArray(gdspy.CellArray, _GeometryHelper):
+    def __init__(self, device, columns, rows, spacing, origin=(0, 0),
+                 rotation=0, magnification=None, x_reflection=False):
+        super(CellArray, self).__init__(
+            columns = columns,
+            rows = rows,
+            spacing = spacing,
+            ref_cell = device,
+            origin=origin,
+            rotation=rotation,
+            magnification=magnification,
+            x_reflection=x_reflection,
+            ignore_missing=False)
+        self.parent = device
+
+    @property
+    def bbox(self):
+        bbox = self.get_bounding_box()
+        if bbox is None:  bbox = ((0,0),(0,0))
+        return np.array(bbox)
+
+
+    def move(self, origin = (0,0), destination = None, axis = None):
+        """ Moves the CellArray from the origin point to the destination.  Both
+         origin and destination can be 1x2 array-like, Port, or a key
+         corresponding to one of the Ports in this device_ref """
+
+        # If only one set of coordinates is defined, make sure it's used to move things
+        if destination is None:
+            destination = origin
+            origin = (0,0)
+
+        if isinstance(origin, Port):            o = origin.midpoint
+        elif np.array(origin).size == 2:    o = origin
+        elif origin in self.ports:    o = self.ports[origin].midpoint
+        else: raise ValueError('[CellArray.move()] ``origin`` not array-like, a port, or port name')
+
+        if isinstance(destination, Port):           d = destination.midpoint
+        elif np.array(destination).size == 2:   d = destination
+        elif destination in self.ports:   d = self.ports[destination].midpoint
+        else: raise ValueError('[CellArray.move()] ``destination`` not array-like, a port, or port name')
+
+        # Lock one axis if necessary
+        if axis == 'x': d = (d[0], o[1])
+        if axis == 'y': d = (o[0], d[1])
+
+        # This needs to be done in two steps otherwise floating point errors can accrue
+        dxdy = np.array(d) - np.array(o)
+        self.origin = np.array(self.origin) + dxdy
+        self.parent._bb_valid = False
+        return self
+
+
+    def rotate(self, angle = 45, center = (0,0)):
+        if angle == 0: return self
+        if type(center) is Port:  center = center.midpoint
+        self.rotation += angle
+        self.origin = _rotate_points(self.origin, angle, center)
+        self.parent._bb_valid = False
+        return self
+
+
+    def reflect(self, p1 = (0,1), p2 = (0,0)):
+        if type(p1) is Port:  p1 = p1.midpoint
+        if type(p2) is Port:  p2 = p2.midpoint
+        p1 = np.array(p1);  p2 = np.array(p2)
+        # Translate so reflection axis passes through origin
+        self.origin = self.origin - p1
+
+        # Rotate so reflection axis aligns with x-axis
+        angle = np.arctan2((p2[1]-p1[1]),(p2[0]-p1[0]))*180/pi
+        self.origin = _rotate_points(self.origin, angle = -angle, center = [0,0])
+        self.rotation -= angle
+
+        # Reflect across x-axis
+        self.x_reflection = not self.x_reflection
+        self.origin[1] = -self.origin[1]
+        self.rotation = -self.rotation
+
+        # Un-rotate and un-translate
+        self.origin = _rotate_points(self.origin, angle = angle, center = [0,0])
+        self.rotation += angle
+        self.origin = self.origin + p1
+
+        self.parent._bb_valid = False
+        return self

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -7,7 +7,13 @@
 # Minor TODO
 #==============================================================================
 # geometry: add packer, basic_wire
+# fix remove -- allow removal of labels and cellarrays
 # Let both References/Arrays/Polygons to be assigned as D['waveguide'] = D << WG
+# Offset improvement for >100,000 polygons:
+#   Get list of polygons, np.vstack together, sort, find where x & y medians,
+#   _chop all polygons along median (so half of points on one side, half on the
+#   other), perform offset on each quadrant of polygons, chop again to cut off
+#   incorrect offsets (at value `distance`), stitch together
 
 #==============================================================================
 # Imports

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -9,7 +9,6 @@
 # Minor TODO
 #==============================================================================
 # geometry: add packer, basic_wire
-# Add CellArray / other gdspy components to tutorial
 # Let both References/Arrays/Polygons to be assigned as D['waveguide'] = D << WG
 # PHIDL fix quickplot "AttributeError: 'DeviceReference' object has no attribute 'aliases'"
 
@@ -1038,7 +1037,6 @@ class DeviceReference(gdspy.CellReference, _GeometryHelper):
         # This needs to be done in two steps otherwise floating point errors can accrue
         dxdy = np.array(d) - np.array(o)
         self.origin = np.array(self.origin) + dxdy
-        self.parent._bb_valid = False
         return self
 
 
@@ -1047,7 +1045,6 @@ class DeviceReference(gdspy.CellReference, _GeometryHelper):
         if type(center) is Port:  center = center.midpoint
         self.rotation += angle
         self.origin = _rotate_points(self.origin, angle, center)
-        self.parent._bb_valid = False
         return self
 
 
@@ -1073,7 +1070,6 @@ class DeviceReference(gdspy.CellReference, _GeometryHelper):
         self.rotation += angle
         self.origin = self.origin + p1
 
-        self.parent._bb_valid = False
         return self
 
 
@@ -1144,7 +1140,6 @@ class CellArray(gdspy.CellArray, _GeometryHelper):
         # This needs to be done in two steps otherwise floating point errors can accrue
         dxdy = np.array(d) - np.array(o)
         self.origin = np.array(self.origin) + dxdy
-        self.parent._bb_valid = False
         return self
 
 
@@ -1153,7 +1148,6 @@ class CellArray(gdspy.CellArray, _GeometryHelper):
         if type(center) is Port:  center = center.midpoint
         self.rotation += angle
         self.origin = _rotate_points(self.origin, angle, center)
-        self.parent._bb_valid = False
         return self
 
 
@@ -1179,5 +1173,4 @@ class CellArray(gdspy.CellArray, _GeometryHelper):
         self.rotation += angle
         self.origin = self.origin + p1
 
-        self.parent._bb_valid = False
         return self

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -64,6 +64,8 @@ def _reflect_points(points, p1 = (0,0), p2 = (1,0)):
     if np.asarray(points).ndim == 2:
         return np.array([2*(p1 + (p2-p1)*np.dot((p2-p1),(p-p1))/norm(p2-p1)**2) - p for p in points])
 
+def _is_iterable(items):
+    return isinstance(items, (list, tuple, set, np.ndarray))
 
 
 def reset():
@@ -498,7 +500,7 @@ class Device(gdspy.Cell, _GeometryHelper):
     def add_ref(self, D, alias = None):
         """ Takes a Device and adds it as a DeviceReference to the current
         Device.  """
-        if type(D) in (list, tuple):
+        if _is_iterable(D):
             return [self.add_ref(E) for E in D]
         if not isinstance(D, Device):
             raise TypeError("""[PHIDL] add_ref() was passed something that
@@ -769,7 +771,7 @@ class Device(gdspy.Cell, _GeometryHelper):
 
 
     def remove(self, items):
-        if type(items) not in (list, tuple):  items = [items]
+        if not _is_iterable(items):  items = [items]
         for item in items:
             if isinstance(item, Port):
                 try:
@@ -1068,7 +1070,7 @@ class DeviceReference(gdspy.CellReference, _GeometryHelper):
             p = port
         else:
             raise ValueError('[PHIDL] connect() did not receive a Port or valid port name' + \
-                ' - received (%s), ports available are (%s)' % (port, self.ports.keys()))
+                ' - received (%s), ports available are (%s)' % (port, tuple(self.ports.keys())))
         self.rotate(angle =  180 + destination.orientation - p.orientation, center = p.midpoint)
         self.move(origin = p, destination = destination)
         self.move(-overlap*np.array([cos(destination.orientation*pi/180),

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -715,14 +715,17 @@ def import_gds(filename, cellname = None, flatten = False):
             # First convert each reference so it points to the right Device
             converted_references = []
             for e in D.references:
-                ref_device = c2dmap[e.ref_cell]
-                dr = DeviceReference(device = ref_device,
-                    origin = e.origin,
-                    rotation = e.rotation,
-                    magnification = e.magnification,
-                    x_reflection = e.x_reflection,
-                    )
-                converted_references.append(dr)
+                if isinstance(e, gdspy.CellReference):
+                    ref_device = c2dmap[e.ref_cell]
+                    dr = DeviceReference(device = ref_device,
+                        origin = e.origin,
+                        rotation = e.rotation,
+                        magnification = e.magnification,
+                        x_reflection = e.x_reflection,
+                        )
+                    converted_references.append(dr)
+                elif isinstance(e, gdspy.CellArray):
+                    converted_references.append(e)
             D.references = converted_references
             # Next convert each Polygon
             temp_polygons = list(D.polygons)

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -121,7 +121,7 @@ def ellipse(radii = (10,5), angle_resolution = 2.5, layer = 0):
     Parameters
     ----------
     radii : tuple
-        Semimajor and semiminor axis lengths of the ellipse.
+        Semimajor (x) and semiminor (y) axis lengths of the ellipse.
     angle_resolution : float
         Resolution of the curve of the ring (# of degrees per point).
     layer : int, array-like[2], or set
@@ -130,12 +130,6 @@ def ellipse(radii = (10,5), angle_resolution = 2.5, layer = 0):
     Returns
     -------
     A Device with an ellipse polygon in it
-
-    Notes
-    -----
-    The orientation of the ellipse is determined by the order of the radii variables;
-    if the first element is larger, the ellipse will be horizontal and if the second
-    element is larger, the ellipse will be vertical.
     """
 
     D = Device(name = 'ellipse')
@@ -692,12 +686,14 @@ def import_gds(filename, cellname = None, flatten = False):
     top_level_cells = gdsii_lib.top_level()
     if cellname is not None:
         if cellname not in gdsii_lib.cell_dict:
-            raise ValueError('[PHIDL] import_gds() The requested cell (named %s) is not present in file %s' % (cellname,filename))
+            raise ValueError('[PHIDL] import_gds() The requested cell (named %s) \
+                        is not present in file %s' % (cellname,filename))
         topcell = gdsii_lib.cell_dict[cellname]
     elif cellname is None and len(top_level_cells) == 1:
         topcell = top_level_cells[0]
     elif cellname is None and len(top_level_cells) > 1:
-        raise ValueError('[PHIDL] import_gds() There are multiple top-level cells, you must specify `cellname` to select of one of them')
+        raise ValueError('[PHIDL] import_gds() There are multiple top-level cells, \
+                        you must specify `cellname` to select of one of them')
 
     if flatten == False:
         D_list = []
@@ -743,10 +739,6 @@ def import_gds(filename, cellname = None, flatten = False):
             D.polygons = []
             for p in temp_polygons:
                 D.add_polygon(p)
-                # else:
-                #     warnings.warn('[PHIDL] import_gds(). Warning an element which was not a ' \
-                #         'polygon, cell, reference exists in the GDS, and was not able to be imported. ' \
-                #         'The element was a: "%s"' % e)
 
         topdevice = c2dmap[topcell]
         return topdevice

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -773,7 +773,7 @@ def _translate_cell(c):
     return D
 
 
-def preview_layerset(ls, size = 100):
+def preview_layerset(ls, size = 100, spacing = 100):
     """ Generates a preview Device with representations of all the layers,
     used for previewing LayerSet color schemes in quickplot or saved .gds
     files """
@@ -793,8 +793,8 @@ def preview_layerset(ls, size = 100):
         T.move((50*scale,-20*scale))
         xloc = n % matrix_size
         yloc = int(n // matrix_size)
-        D.add_ref(R).movex(200 * xloc *scale).movey(-200 * yloc*scale)
-        D.add_ref(T).movex(200 * xloc *scale).movey(-200 * yloc*scale)
+        D.add_ref(R).movex((100+spacing) * xloc *scale).movey(-(100+spacing) * yloc*scale)
+        D.add_ref(T).movex((100+spacing) * xloc *scale).movey(-(100+spacing) * yloc*scale)
     return D
 
 class device_lru_cache:

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -2639,8 +2639,8 @@ def snspd(wire_width = 0.2, wire_pitch = 0.6, size = (10,8),
 
 
 def snspd_expanded(wire_width = 0.2, wire_pitch = 0.6, size = (10,8),
-           num_squares = None, connector_width = 1, turn_ratio = 4,
-           terminals_same_side = False, layer = 0):
+           num_squares = None, connector_width = 1, connector_symmetric = False,
+            turn_ratio = 4, terminals_same_side = False, layer = 0):
     """ Creates an optimally-rounded SNSPD with wires coming out of it that expand"""
     D = Device('snspd_expanded')
     S = snspd(wire_width = wire_width, wire_pitch = wire_pitch,
@@ -2649,7 +2649,7 @@ def snspd_expanded(wire_width = 0.2, wire_pitch = 0.6, size = (10,8),
     s = D.add_ref(S)
     step_device = optimal_step(start_width = wire_width, end_width = connector_width,
                             num_pts = 100, anticrowding_factor = 2, width_tol = 1e-3,
-                            layer = layer)
+                            symmetric = connector_symmetric, layer = layer)
     step1 = D.add_ref(step_device)
     step2 = D.add_ref(step_device)
     step1.connect(port = 1, destination = s.ports[1])

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -670,7 +670,11 @@ def deepcopy(D):
     Device._next_uid += 1
     D_copy._internal_name = D._internal_name
     D_copy.name = '%s%06d' % (D_copy._internal_name[:20], D_copy.uid) # Write name e.g. 'Unnamed000005'
-
+    # Make sure _bb_valid is set to false for these new objects so new
+    # bounding boxes are created in the cache
+    for D in D_copy.get_dependencies(True):
+        D._bb_valid = False
+        
     return D_copy
 
 

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -527,10 +527,10 @@ def _merge_floating_point_errors(polygons, tol = 1e-10):
 def _merge_nearby_floating_points(x, tol = 1e-10):
     """ Takes an array `x` and merges any values within the tolerance `tol`
     So if given
-    >>> x = [-2, -1, 0, 1.00001, 1.0002, 1.0003, 4, 5, 5.003, 6, 7, 8]
+    >>> x = [-2, -1, 0, 1.0001, 1.0002, 1.0003, 4, 5, 5.003, 6, 7, 8]
     >>> _merge_nearby_floating_points(x, tol = 1e-3)
     will then return:
-    >>> [-2, -1, 0, 1.00001, 1.0001, 1.0001, 4, 5, 5.003, 6, 7, 8] """
+    >>> [-2, -1, 0, 1.0001, 1.0001, 1.0001, 4, 5, 5.003, 6, 7, 8] """
     xargsort = np.argsort(x)
     xargunsort = np.argsort(xargsort)
     xsort = x[xargsort]

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1182,11 +1182,11 @@ def _G_integrand(xip, B):
 
 def _G(xi, B):
     try:
-        from scipy.optimize import integrate
+        import scipy.integrate
     except:
         raise ImportError(""" [PHIDL] To run the microsctrip functions you need scipy,
           please install it with `pip install scipy` """)
-    return B/sinh(B)*integrate.quad(_G_integrand, 0, xi, args = (B))[0]
+    return B/sinh(B)*scipy.integrate.quad(_G_integrand, 0, xi, args = (B))[0]
 
 @device_lru_cache
 def hecken_taper(length = 200, B = 4.0091, dielectric_thickness = 0.25, eps_r = 2,

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -992,7 +992,7 @@ def flagpole(size = (4,2), stub_size = (2,1), shape = 'p', taper_type = 'straigh
     shape = shape.lower()
 
     assert shape in 'pqbd', '[DEVICE]  flagpole() shape must be p, q, b, or D'
-    assert taper_type in ['straight','fillet'], '[DEVICE]  flagpole() taper_type must "straight" or "fillet" or None'
+    assert taper_type in ['straight','fillet',None], '[DEVICE]  flagpole() taper_type must "straight" or "fillet" or None'
 
     if shape ==   'p':
         orientation = -90

--- a/phidl/phidl_tutorial_example.py
+++ b/phidl/phidl_tutorial_example.py
@@ -324,6 +324,23 @@ for p in all_ports:
 
 
 #==============================================================================
+# Advanced: Using CellArray
+#==============================================================================
+# In GDS, there's a type of structure called a "CellArray" which takes a cell
+# and repeats it NxM times on a fixed grid spacing.  For convenience, PHIDL
+# includes this functionality with the add_array() function.  Note that
+# CellArrays are not compatible with ports (since there is no way to 
+# access/modify individual elements in a GDS cellarray)
+
+D = Device()
+R = pg.rectangle([30,20])
+a = D.add_array(R, columns = 7, rows = 5,  spacing = (31, 21))
+# bbox gets the bounding box of the whole array
+a.bbox.tolist() == [[0.0, 0.0], [216.0, 104.0]] 
+qp(D)
+
+
+#==============================================================================
 # Adding premade geometry with phidl.geometry
 #==============================================================================
 # Usually at the beginning of a phidl file we import the phidl.geometry module

--- a/phidl/quickplotter.py
+++ b/phidl/quickplotter.py
@@ -70,9 +70,10 @@ def quickplot(items, show_ports = True, show_subports = True,
                         ax.text(port.midpoint[0], port.midpoint[1], name)
             if isinstance(item, Device) and show_subports is True:
                 for sd in item.references:
-                    for name, port in sd.ports.items():
-                        _draw_port(port, arrow_scale = 1, shape = 'right', color = 'r')
-                        ax.text(port.midpoint[0], port.midpoint[1], name)
+                    if not isinstance(sd, (gdspy.CellArray)):
+                        for name, port in sd.ports.items():
+                            _draw_port(port, arrow_scale = 1, shape = 'right', color = 'r')
+                            ax.text(port.midpoint[0], port.midpoint[1], name)
             if isinstance(item, Device) and label_aliases is True:
                 for name, ref in item.aliases.items():
                     ax.text(ref.x, ref.y, str(name), style = 'italic', color = 'blue',
@@ -623,8 +624,9 @@ def quickplot2(item_list, *args, **kwargs):
             # If element is a Device, draw ports and aliases
             if isinstance(element, phidl.device_layout.Device):
                 for ref in element.references:
-                    for name, port in ref.ports.items():
-                        viewer.add_port(port, is_subport = True)
+                    if not isinstance(ref, gdspy.CellArray):
+                        for name, port in ref.ports.items():
+                            viewer.add_port(port, is_subport = True)
                 for name, port in element.ports.items():
                     viewer.add_port(port)
                     viewer.add_aliases(element.aliases)

--- a/phidl/quickplotter.py
+++ b/phidl/quickplotter.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 
 import phidl
-from phidl.device_layout import Device, DeviceReference, Port, Layer, Polygon
+from phidl.device_layout import Device, DeviceReference, CellArray, Layer, Polygon
 import gdspy
 
 
@@ -60,12 +60,14 @@ def quickplot(items, show_ports = True, show_subports = True,
                 layerprop = _get_layerprop(layer = key[0], datatype = key[1])
                 _draw_polygons(polygons, ax, facecolor = layerprop['color'],
                                edgecolor = 'k', alpha = layerprop['alpha'])
-                for name, port in item.ports.items():
-                    if (port.width is None) or (port.width == 0):
-                        _draw_port_as_point(port)
-                    else:
-                        _draw_port(port, arrow_scale = 2, shape = 'full', color = 'k')
-                    ax.text(port.midpoint[0], port.midpoint[1], name)
+                # If item is a Device or DeviceReference, draw ports
+                if isinstance(item, (Device, DeviceReference)):
+                    for name, port in item.ports.items():
+                        if (port.width is None) or (port.width == 0):
+                            _draw_port_as_point(port)
+                        else:
+                            _draw_port(port, arrow_scale = 2, shape = 'full', color = 'k')
+                        ax.text(port.midpoint[0], port.midpoint[1], name)
             if isinstance(item, Device) and show_subports is True:
                 for sd in item.references:
                     for name, port in sd.ports.items():

--- a/phidl_tutorial_example.ipynb
+++ b/phidl_tutorial_example.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# About this notebook\n",
+    "\n",
+    "This notebook is just used to quickly demonstrate some basic functionality of PHIDL.  For a much more expansive tutorial with more thorough explanations, please see the phidl_tutorial_example.py file (link here: [phidl_tutorial_example.py](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py#L26) )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook\n",
+    "from phidl import Device\n",
+    "from phidl import quickplot as qp # Rename \"quickplot()\" to the easier \"qp()\"\n",
+    "import phidl.geometry as pg\n",
+    "\n",
+    "\n",
+    "# Create a blank device (essentially an empty GDS cell with some special features)\n",
+    "D = Device('mydevice')\n",
+    "\n",
+    "# Create and add a polygon from separate lists of x points and y points\n",
+    "# e.g. [(x1, x2, x3, ...), (y1, y2, y3, ...)]\n",
+    "poly1 = D.add_polygon( [(8,6,7,9), (6,8,9,5)] )\n",
+    "\n",
+    "# Alternatively, create and add a polygon from a list of points\n",
+    "# e.g. [(x1,y1), (x2,y2), (x3,y3), ...] using the same function\n",
+    "poly2 = D.add_polygon( [(0, 0), (1, 1), (1, 3), (-3, 3)] )\n",
+    "\n",
+    "qp(D) # quickplot it!\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/phidl_tutorial_example.ipynb
+++ b/phidl_tutorial_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# About this notebook\n",
     "\n",
-    "This notebook is just used to quickly demonstrate some basic functionality of PHIDL.  For a much more expansive tutorial with more thorough explanations, please see the phidl_tutorial_example.py file (link here: [phidl_tutorial_example.py](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py#L26) )\n"
+    "This notebook is just used to quickly demonstrate some basic functionality of PHIDL.  For a much more expansive tutorial with more thorough explanations, please see the phidl_tutorial_example.py file (link here: [phidl_tutorial_example.py](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py#L35) )\n"
    ]
   },
   {

--- a/phidl_tutorial_example.ipynb
+++ b/phidl_tutorial_example.ipynb
@@ -15,7 +15,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Boilerplate stuff \n",
     "%matplotlib notebook\n",
+    "import warnings; warnings.filterwarnings(\"ignore\")\n",
+    "\n",
     "from phidl import Device\n",
     "from phidl import quickplot as qp # Rename \"quickplot()\" to the easier \"qp()\"\n",
     "import phidl.geometry as pg\n",
@@ -25,14 +28,36 @@
     "D = Device('mydevice')\n",
     "\n",
     "# Create and add a polygon from separate lists of x points and y points\n",
-    "# e.g. [(x1, x2, x3, ...), (y1, y2, y3, ...)]\n",
-    "poly1 = D.add_polygon( [(8,6,7,9), (6,8,9,5)] )\n",
+    "# (Can also be added like [(x1,y1), (x2,y2), (x3,y3), ... ]\n",
+    "poly1 = D.add_polygon( [(-8,6,7,9), (-6,8,17,5)], layer = 0)\n",
     "\n",
-    "# Alternatively, create and add a polygon from a list of points\n",
-    "# e.g. [(x1,y1), (x2,y2), (x3,y3), ...] using the same function\n",
-    "poly2 = D.add_polygon( [(0, 0), (1, 1), (1, 3), (-3, 3)] )\n",
+    "# Create some new geometry from the functions available in the geometry library\n",
+    "T = pg.text('Hello!')\n",
+    "C = pg.arc(radius = 25, width = 2, theta = 45, layer = 1)\n",
+    "R = pg.rectangle(size = [5,10], layer = 2)\n",
+    "\n",
+    "# Add references to the new geometry to D, our blank device\n",
+    "text1 = D.add_ref(T) # Add the text we created as a reference\n",
+    "text2 = D << T # Using the << operator (identical to add_ref()), add the same geometry a second time\n",
+    "c = D << C # Add the arc we created\n",
+    "r = D << R # Add the rectangle we created\n",
+    "\n",
+    "# Now that the geometry has been added to \"D\", we can move everything around:\n",
+    "text1.movey(25)\n",
+    "text2.move([5,30])\n",
+    "text2.rotate(45)\n",
+    "r.movex(-15)\n",
     "\n",
     "qp(D) # quickplot it!\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Smarter movement with **ports**\n",
+    "\n",
+    "Any Device can have \"Port\"s in it which allow you to snap geometry together like legos.  Below is an example where we write a simple function to make a rectangular waveguide, assign ports to the ends of the rectangle, and then snap those rectangles together"
    ]
   },
   {
@@ -41,7 +66,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "b"
+    "\n",
+    "def waveguide(width = 10, height = 1, layer = 0):\n",
+    "    WG = Device('waveguide')\n",
+    "    WG.add_polygon( [(0, 0), (width, 0), (width, height), (0, height)], layer = layer)\n",
+    "    WG.add_port(name = 'wgport1', midpoint = [0,height/2], width = height, orientation = 180)\n",
+    "    WG.add_port(name = 'wgport2', midpoint = [width,height/2], width = height, orientation = 0)\n",
+    "    return WG\n",
+    "\n",
+    "D = Device()\n",
+    "\n",
+    "wg1 = D << waveguide(width=6, height = 2.5, layer = 1)\n",
+    "wg2 = D << waveguide(width=11, height = 2.5, layer = 2)\n",
+    "wg3 = D << waveguide(width=15, height = 2.5, layer = 3)\n",
+    "wg2.movey(10).rotate(10)\n",
+    "wg3.movey(20).rotate(15)\n",
+    "\n",
+    "# And plot the result!\n",
+    "qp(D, new_window = True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now we can connect everything together using the ports:\n",
+    "\n",
+    "# Each waveguide has two ports: 'wgport1' and 'wgport2'.  These are arbitrary \n",
+    "# names defined in our waveguide() function above\n",
+    "\n",
+    "# Let's keep wg1 in place on the bottom, and connect the other waveguides to it.\n",
+    "# To do that, on wg2 we'll grab the \"wgport1\" port and connect it to the \"wgport2\" on wg1:\n",
+    "wg2.connect('wgport1', wg1.ports['wgport2'])\n",
+    "# Next, on wg3 let's grab the \"wgport1\" port and connect it to the \"wgport2\" on wg2:\n",
+    "wg3.connect('wgport1', wg2.ports['wgport2'])\n",
+    "\n",
+    "# And plot the result!\n",
+    "qp(D, new_window = True)\n"
    ]
   },
   {
@@ -68,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+matplotlib
+scipy
+webcolors
+gdspy
+phidl

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires=[
 ]
 
 setup(name='phidl',
-      version='1.0.3',
+      version='1.1.0',
       description='PHIDL',
       install_requires=install_requires,
       author='Adam McCaughan',

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -26,6 +26,27 @@ def test_add_polygon3():
     h = D.hash_geometry(precision = 1e-4)
     assert(h == '96abc3c9e30f3bbb32c5a39aeea2ba0fa3b13ebe')
     
+
+def test_add_array():
+    D = Device()
+    E = pg.rectangle(size = (30, 20), layer = 7)
+    A = D.add_array(E, columns = 7, rows = 5,  spacing = (31, 21))
+    assert(A.bbox.tolist() == [[0.0, 0.0], [216.0, 104.0]])
+    A.rotate(10)
+    A.move((15,1.5))
+    A.reflect((0,1))
+    A.get_polygons()
+    h = D.hash_geometry(precision = 1e-4)
+    assert(h == '418b7503baff80fbe93031d45d87557c277f07b4')
+    
+    F = Device()
+    f1 = F << D
+    f2 = F << D
+    f1.movex(300)
+    f2.rotate(45)
+    h = F.hash_geometry(precision = 1e-4)
+    assert(h == 'fd7c2b4adb811342b836d9fca13992eff951630d')
+    
     
 # Test polygon manipulation
 def test_move():

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -29,7 +29,8 @@ def test_add_polygon3():
 
 def test_add_array():
     D = Device()
-    E = pg.rectangle(size = (30, 20), layer = 7)
+    E = Device()
+    E.add_polygon([[30, 20], [30,  0], [ 0,  0], [ 0, 20]], layer = 7)
     A = D.add_array(E, columns = 7, rows = 5,  spacing = (31, 21))
     assert(A.bbox.tolist() == [[0.0, 0.0], [216.0, 104.0]])
     A.rotate(10)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -26,6 +26,28 @@ def test_add_polygon3():
     h = D.hash_geometry(precision = 1e-4)
     assert(h == '96abc3c9e30f3bbb32c5a39aeea2ba0fa3b13ebe')
     
+def test_bbox():
+    D = Device()
+    D.add_polygon( [(0,0), (10,0), (10,10), (0,10)], layer = 2)
+    assert(D._bb_valid == False)
+    # Calculating the bbox should change _bb_valid to True once it's cached
+    assert(D.bbox.tolist() == [[0,0], [10,10]])
+    assert(D._bb_valid == True)
+
+    E = Device()
+    e1 = E.add_ref(D)
+    e2 = E.add_ref(D)
+    e2.movex(30)
+    assert(E._bb_valid == False)
+    assert(E.bbox.tolist() == [[0,0], [40,10]])
+    assert(E._bb_valid == True)
+
+    D.add_polygon( [(0,0), (100,0), (100,100), (0,100)], layer = 2)
+    D.add_polygon( [(0,0), (100,0), (100,100), (0,100)], layer = 2)
+    assert(E.bbox.tolist() == [[0,0], [130,100]])
+    assert(e1.bbox.tolist() == [[0,0], [100,100]])
+    assert(e2.bbox.tolist() == [[30,0], [130,100]])
+
 
 def test_add_array():
     D = Device()


### PR DESCRIPTION
## 1.1.0 (October 16, 2019)

### New features
- New online notebook to try out PHIDL!  Try now in an interactive online notebook: [Link](https://mybinder.org/v2/gh/amccaugh/phidl/jupyter-notebook2?filepath=phidl_tutorial_example.ipynb)
- Added full CellArray support, use the `D.add_array()` function (see the [tutorial](https://github.com/amccaugh/phidl/blob/master/phidl/phidl_tutorial_example.py) for more details)
- Allow plotting of `DeviceReference`s directly in `quickplot`

### Changes
- Added `connector_symmetric` argument to `pg.snspd_expanded()`

### Bugfixes
- Bounding box cache speed improvement