### PR TITLE
Testing and CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ install:
   - pip install --upgrade pip
   - pip install -U matplotlib==2.2.3 # Needed because Travis CI pulls 3.0.2 even though it doesn't work with Python 2.7
   - pip install -U scipy==1.1.0 # Compatible with Python 2 and 3
-  - python setup.py install
+  - pip install lytest  # For XOR testing
+  - pip install .
 
 script:
   - python ./phidl/phidl_tutorial_example.py
-  - pytest
+  - pytest tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy
 matplotlib
 webcolors
 gdspy
-phidl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+''' This runs before every test, even if they happen in parallel.
+    Use it for setting up a consistent state of global variables or setting up directories
+'''
 # make sure phidl is on path
 import os, sys
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+# make sure phidl is on path
+import os, sys
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning


### PR DESCRIPTION
Fixed various issues with travis that came up. For example, `python setup.py install` does not collect new modules sometimes, while `pip install .` does.

conftest.py: run things before testing to set in consistent starting state

pytest.ini: suppress warnings that can drown out real information