### PR TITLE
PHIDL 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 1.4.1 (Oct 10, 2020)
+## 1.4.2 (Oct 7, 2020)
+
+Bugfix release
+
+### Bugfixes
+- Fix for Device xmin/xmax/ymin/ymax property assignment (e.g. `D.xmin = 30`) causing incorrect movement of references and labels
+
+
+## 1.4.1 (Oct 6, 2020)
 
 ### New features
 - Added font support to `pg.text()` - Now you can use built-in fonts or specify a .TTF/.OTF font, including full unicode support (thanks to Sebastian Pauka @spauka).  See the [geometry reference library here](https://phidl.readthedocs.io/en/latest/geometry_reference.html#Text)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GDS scripting that's intuitive, fast, and powerful.  For Python 2 and 3.
 - [**Installation / requirements**](#installation--requirements)
 - [**Tutorial + examples**](https://phidl.readthedocs.io/en/latest/tutorials.html) (or [try an interactive notebook](https://mybinder.org/v2/gh/amccaugh/phidl/master?filepath=phidl_tutorial_example.ipynb))
 - [**Geometry library + function documentation**](https://phidl.readthedocs.io/)
-- [Changelog](https://github.com/amccaugh/phidl/blob/master/CHANGELOG.md) (latest update 1.4.1 (Oct 6, 2020))
+- [Changelog](https://github.com/amccaugh/phidl/blob/master/CHANGELOG.md) (latest update 1.4.2 (Oct 7, 2020))
   - Added font support to `pg.text()` [more info here](https://phidl.readthedocs.io/en/latest/geometry_reference.html#Text)
   - Added waypoint-based pathing `pp.smooth()`  [more info here](https://phidl.readthedocs.io/en/latest/tutorials/waveguides.html#Waypoint-based-path-creation)
   - You can now easily [`Group` objects together](https://phidl.readthedocs.io/en/latest/tutorials/group.html)

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -1611,9 +1611,9 @@ class Device(gdspy.Cell, _GeometryHelper):
         for e in self.polygons:
             e.translate(dx,dy)
         for e in self.references:
-            e.move(destination = destination, origin = origin)
+            e.move((dx,dy))
         for e in self.labels:
-            e.move(destination = destination, origin = origin)
+            e.move((dx,dy))
         for p in self.ports.values():
             p.midpoint = np.array(p.midpoint) + np.array((dx,dy))
 

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -53,7 +53,7 @@ from phidl.constants import _CSS3_NAMES_TO_HEX
 import gdspy.library
 gdspy.library.use_current_library = False
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'
 
 
 #==============================================================================

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 setup(name='phidl',
-      version='1.4.1',
+      version='1.4.2',
       description='PHIDL',
       long_description = long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
## 1.4.2 (Oct 7, 2020)

Bugfix release

### Bugfixes
- Fix for Device xmin/xmax/ymin/ymax property assignment (e.g. `D.xmin = 30`) causing incorrect movement of references and labels
