### PR TITLE
Allow path.smooth to start with non-horizontal path

### DIFF
--- a/phidl/path.py
+++ b/phidl/path.py
@@ -351,7 +351,9 @@ def smooth(
     new_points.append( [points[-1,:]] )
     new_points = np.concatenate(new_points)
 
-    P = Path(new_points)
+    P = Path()
+    P.rotate(theta[0])
+    P.append(new_points)
     P.move(points[0,:])
 
     return P


### PR DESCRIPTION
Hey,

This pull request fixes a bug that required the points that are passed in to path.smooth to start with a horizontal segment that moves to the right.

When starting with a horizontal segment, `path.smooth` correctly passes via each waypoint:
```py3
points = np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
path = pp.smooth(points, radius=0.1)
qp(path)
fig = plt.figure('PHIDL quickplot')
ax = fig.axes[0]
ax.scatter(points[:,0], points[:,1])
```
![good1](https://user-images.githubusercontent.com/635580/96409786-95272480-1231-11eb-9423-8842f66f3f1e.png)

To trigger the bug, one can use a path that does not begin with a horizontal segment
```py3
points = np.array([[0, 0], [-1, 0], [-1, 1], [0, 1]])
path = pp.smooth(points, radius=0.1)
qp(path)
fig = plt.figure('PHIDL quickplot')
ax = fig.axes[0]
ax.scatter(points[:,0], points[:,1])
ax.set_xlim((-1.2, 1.2))
ax.set_ylim((-1.2, 1.2))
```
![bad1](https://user-images.githubusercontent.com/635580/96409805-9c4e3280-1231-11eb-952d-a45917151946.png)

To fix, we apply a rotation at the beginning of the path to face the correct direction. Afterwards, we get the expected result:
![good2](https://user-images.githubusercontent.com/635580/96409821-a07a5000-1231-11eb-96be-bd81de8306ad.png)
