### PR TITLE
Fix curlicue turns in path.smooth

### DIFF
--- a/phidl/path.py
+++ b/phidl/path.py
@@ -321,6 +321,7 @@ def smooth(
     ds = np.sqrt(dx**2 + dy**2)
     theta = np.degrees(np.arctan2(dy,dx))
     dtheta = np.diff(theta)
+    dtheta = dtheta - 360*np.floor((dtheta + 180)/360)
 
     # FIXME add caching
     # Create arcs


### PR DESCRIPTION
Hi, 

First, thanks for all your work on this repository! It's been very nice to work with and makes layouts much easier.

I found that path.smooth will make funny curlicue turns in some cases. For example, when the path goes from pointing south to pointing west, the path will circle left 270 degrees instead of just turning 90 degrees right.  Here's a snippet to reproduce the problem:
```
import numpy as np
from matplotlib import pyplot as plt
from phidl import quickplot as qp
import phidl.path as pp

points = np.array([(0, -10), (0, 0), (-10, 0), (-10, -10), (-20, -10), (-20, 0)])
path = pp.smooth(points, radius=1)
qp(path)
plt.show()
```
![before](https://user-images.githubusercontent.com/11377509/108912847-2dc21c80-75f7-11eb-8ad0-98c2fd408917.png)

The curlicue turns are caused by the turn angle calculation, which can produce turn angles in the range [-360, 360]. Wrapping the turn angle into the range [-180, 180] fixes the problem:
![after](https://user-images.githubusercontent.com/11377509/108913788-762e0a00-75f8-11eb-9b0e-85d1ec33183e.png)