### PR TITLE
Add 180° rotation to ports on pg.compass_multi

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1989,7 +1989,7 @@ def compass(size=(4,2), layer=0):
     return D
 
 
-def compass_multi(size = (4, 2), ports = {'N':3,'S':4}, layer = 0):
+def compass_multi(size = (4, 2), ports = {'N':3,'S':4}, flip_ports=False, layer = 0):
     """ Creates a rectangular contact pad with multiple ports along the edges
     rectangle (north, south, east, and west).
 
@@ -1999,6 +1999,8 @@ def compass_multi(size = (4, 2), ports = {'N':3,'S':4}, layer = 0):
         Dimensions of the rectangular contact pad.
     ports : dict
         Number of ports on each edge of the rectangle.
+    flip_ports : bool
+        If false, the ports face outward. If true the ports face inward.
     layer : int, array-like[2], or set
         Specific layer(s) to put polygon geometry on.
 
@@ -2013,34 +2015,38 @@ def compass_multi(size = (4, 2), ports = {'N':3,'S':4}, layer = 0):
 
     dx = size[0]/2
     dy = size[1]/2
-
+    
+    flipper = 0
+    if flip_ports:
+        flipper = 180
+        
     if 'N' in ports:
         num_ports = ports['N']
         m = dx - dx/num_ports
         p_list = np.linspace(-m, m, num_ports)
         [D.add_port(name = ('N%s' % (n+1)), midpoint = [p, dy],
-                    width = dx/num_ports * 2, orientation = 90)
+                    width = dx/num_ports * 2, orientation = 90+flipper)
          for n, p in enumerate(p_list)]
     if 'S' in ports:
         num_ports = ports['S']
         m = dx - dx/num_ports
         p_list = np.linspace(-m, m, num_ports)
         [D.add_port(name = ('S%s' % (n+1)), midpoint = [p, -dy],
-                    width = dx/num_ports * 2, orientation = -90)
+                    width = dx/num_ports * 2, orientation = -90+flipper)
          for n, p in enumerate(p_list)]
     if 'E' in ports:
         num_ports = ports['E']
         m = dy - dy/num_ports
         p_list = np.linspace(-m, m, num_ports)
         [D.add_port(name = ('E%s' % (n+1)), midpoint = [dx, p],
-                    width = dy/num_ports * 2, orientation = 0)
+                    width = dy/num_ports * 2, orientation = 0+flipper)
          for n, p in enumerate(p_list)]
     if 'W' in ports:
         num_ports = ports['W']
         m = dy - dy/num_ports
         p_list = np.linspace(-m, m, num_ports)
         [D.add_port(name = ('W%s' % (n+1)), midpoint = [-dx, p],
-                    width = dy/num_ports * 2, orientation = 180)
+                    width = dy/num_ports * 2, orientation = 180+flipper)
          for n, p in enumerate(p_list)]
 
     return D

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3673,6 +3673,32 @@ def _via_iterable(via_spacing, wire_width, wiring1_layer, wiring2_layer,
 
     return VI
 
+def rotate_ports(D, angle = 180, depth=None):
+    '''
+    Parameters
+    ----------
+    D : Device
+        DESCRIPTION.
+    angle : float, 
+        angle in degrees to be added to the current orientation of each port. 
+        The default is 180.
+
+    Returns
+    -------
+    D : Device
+        The device object with rotated ports.
+
+    '''
+    port_list=[]
+    port_list = D.get_ports(depth)
+    print()
+    for port in port_list:
+        D.remove(D.ports[port.name])
+        port.orientation += angle
+        D.add_port(port=port)
+        
+    return D
+
 def test_via(num_vias = 100, wire_width = 10, via_width = 15,
              via_spacing = 40, pad_size = (300, 300), min_pad_spacing = 0,
              pad_layer = 0, wiring1_layer = 1, wiring2_layer = 2,


### PR DESCRIPTION
I needed the ports facing a inward/outward for use with pr.route_basic(). `flip_ports` (bool) will add 180° to the orientation of each port.