### PR TITLE
raise error if empty_transition

### DIFF
--- a/phidl/path.py
+++ b/phidl/path.py
@@ -397,7 +397,8 @@ def transition(cross_section1, cross_section2, width_type = 'sine'):
     Xtrans = CrossSection()
 
     if not X1.aliases or not X2.aliases:
-        raise ValueError("No named sections in X1 and X2")
+        raise ValueError("""[PHIDL] transition() found no named sections in one
+        or both inputs (cross_section1/cross_section2).""")
 
     for alias in X1.aliases.keys():
         if alias in X2.aliases:

--- a/phidl/path.py
+++ b/phidl/path.py
@@ -395,6 +395,10 @@ def transition(cross_section1, cross_section2, width_type = 'sine'):
     X1 = cross_section1
     X2 = cross_section2
     Xtrans = CrossSection()
+
+    if not X1.aliases or not X2.aliases:
+        raise ValueError("No named sections in X1 and X2")
+
     for alias in X1.aliases.keys():
         if alias in X2.aliases:
 


### PR DESCRIPTION
Hi Adam,

The new path module is great ^^

It you transition Cross-sections where one of the cross-section does not have any named sections you get an empty Device

with this fix, it will raise an error instead of returning an empty Device

```
from phidl import CrossSection, Device
import phidl.path as pp

from phidl import quickplot as qp

# Create our first CrossSection. Note THAT THERE ARE NO NAMED SECTIONS
X1 = CrossSection()
X1.add(width=1.2, offset=0, layer=2, ports=("in1", "out1"))
X1.add(width=2.2, offset=0, layer=3)
X1.add(width=1.1, offset=3, layer=1)

# Create the second CrossSection that we want to transition to
X2 = CrossSection()
X2.add(width=1, offset=0, layer=2, name="wg", ports=("in2", "out2"))
X2.add(width=3.5, offset=0, layer=3, name="etch")
X2.add(width=3, offset=5, layer=1, name="wg2")

# To show the cross-sections, let's create two Paths and
# create Devices by extruding them
P1 = pp.straight(length=5)
P2 = pp.straight(length=5)
WG1 = P1.extrude(cross_section=X1)
WG2 = P2.extrude(cross_section=X2)

# Place both cross-section Devices and quickplot them
D = Device()
wg1 = D << WG1
wg2 = D << WG2
wg2.movex(7.5)

qp(D)

# Create the transitional CrossSection
Xtrans = pp.transition(cross_section1=X1, cross_section2=X2, width_type="sine")
# Create a Path for the transitional CrossSection to follow
P3 = pp.straight(length=15)
# Use the transitional CrossSection to create a Device
WG_trans = P3.extrude(Xtrans)

qp(WG_trans)
```

