### PR TITLE
fix `num_squares` calculation for `optimal_step`

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -4636,8 +4636,6 @@ def optimal_step(start_width = 10, end_width = 22, num_pts = 50,
 
         ypts[-1] = end_width
         ypts[0] = start_width
-        y_num_sq = np.array(ypts)
-        x_num_sq = np.array(xpts)
 
         if symmetric == False:
             xpts.append(xpts[-1])
@@ -4677,6 +4675,8 @@ def optimal_step(start_width = 10, end_width = 22, num_pts = 50,
         D.add_port(name = 2, midpoint = [max(xpts), 0], width = end_width,
                    orientation = 0)
 
+    y_num_sq = np.array(ypts)
+    x_num_sq = np.array(xpts)
     D.info['num_squares'] = np.sum(np.diff(x_num_sq) /((y_num_sq[:-1] + y_num_sq[1:])/2) )
     return D
 


### PR DESCRIPTION
Issue: running optimal_step with equal `start_width` and `end_width` results in an UnboundLocalError.
```Traceback (most recent call last):
  File "~/reedf_layout/test.py", line 47, in <module>
    D << pg.optimal_step(start_width=10,end_width=10)
  File "~/anaconda3/envs/NanoFab/lib/python3.10/site-packages/phidl/geometry.py", line 1791, in __call__
    new_cache_item = self.fn(*args, **kwargs)
  File "~/anaconda3/envs/NanoFab/lib/python3.10/site-packages/phidl/geometry.py", line 4680, in optimal_step
    D.info['num_squares'] = np.sum(np.diff(x_num_sq) /((y_num_sq[:-1] + y_num_sq[1:])/2) )
UnboundLocalError: local variable 'x_num_sq' referenced before assignment
```
Solution:
fix edge case for calculation of device info `num_squares` when start_width==end_width for `optimal_step`