### PR TITLE
fix absorb

### DIFF
--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -1650,6 +1650,8 @@ class Device(gdspy.Cell, _GeometryHelper):
         ref_polygons = reference.get_polygons(by_spec=True)
         for (layer, polys) in ref_polygons.items():
             [self.add_polygon(points=p, layer=layer) for p in polys]
+        self.add(reference.parent.labels)
+        self.add(reference.parent.paths)
         self.remove(reference)
         return self
 


### PR DESCRIPTION
Hi Adam,

at the moment when absorbing a reference the labels disappear

this PR makes that when you absorb a reference the labels are copied too so they don't get removed
