### PR TITLE
Fix a bug in geometry.outline() for distance < 0

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -728,7 +728,7 @@ def outline(
     Outline = boolean(
         A=D_bloated,
         B=[D, Trim],
-        operation="A-B",
+        operation="A-B" if distance > 0 else "B-A",
         num_divisions=num_divisions,
         max_points=max_points,
         precision=precision,


### PR DESCRIPTION
Boolean operation within geometry.outline() should be "B-A" for distance < 0.