### PR TITLE
Check whether a numbers.Number is used to make work with np.int64

### DIFF
--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -36,6 +36,7 @@
 
 
 import hashlib
+import numbers
 import warnings
 from copy import deepcopy as _deepcopy
 
@@ -540,7 +541,7 @@ def _parse_layer(layer):
         gds_layer, gds_datatype = layer[0], 0
     elif layer is None:
         gds_layer, gds_datatype = 0, 0
-    elif isinstance(layer, (int, float)):
+    elif isinstance(layer, numbers.Number):
         gds_layer, gds_datatype = layer, 0
     else:
         raise ValueError(


### PR DESCRIPTION
When importing a GDS the layer number is a np.int64 instead of int.

Therefore `_parse_layer` isn't working correctly. This fixes it.