### PR TITLE
Preserve Polygon.properties and DeviceReference.properties when saving and loading

### DIFF
--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -1206,9 +1206,13 @@ class Device(gdspy.Cell, _GeometryHelper):
                 layers = zip(points.layers, points.datatypes)
             else:
                 layers = [layer] * len(points.polygons)
-            return [
-                self.add_polygon(p, layer) for p, layer in zip(points.polygons, layers)
-            ]
+
+            polygons = []
+            for p, layer in zip(points.polygons, layers):
+                new_polygon = self.add_polygon(p, layer)
+                new_polygon.properties = points.properties
+                polygons.append(new_polygon)
+            return polygons
 
         if layer is np.nan:
             layer = 0

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1814,7 +1814,7 @@ def import_gds(filename, cellname=None, flatten=False):
                     layer=(label.layer, label.texttype),
                 )
                 l.anchor = label.anchor
-            c2dmap.update({cell: D})
+            c2dmap[cell] = D
             D_list.append(D)
 
         for D in D_list:

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1830,6 +1830,7 @@ def import_gds(filename, cellname=None, flatten=False):
                         magnification=e.magnification,
                         x_reflection=e.x_reflection,
                     )
+                    dr.properties = e.properties
                     dr.owner = D
                     converted_references.append(dr)
                 elif isinstance(e, gdspy.CellArray):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,7 +1,10 @@
+import os
+import tempfile
+
 import numpy as np
 
 import phidl.geometry as pg
-from phidl import Device, Group  # , Layer, LayerSet, make_device, Port
+from phidl import Device, Group
 
 # import phidl.routing as pr
 # import phidl.utilities as pu
@@ -328,3 +331,15 @@ def test_polygon_simplify():
     h = D.hash_geometry(precision=1e-4)
     assert h == "7d9ebcb231fb0107cbbf618353adeb583782ca11"
     # qp(D)
+
+
+def test_preserve_properties():
+    fname = os.path.join(tempfile.mkdtemp(), "properties.gds")
+    d = pg.bbox()
+    d.polygons[0].properties[1] = "yolo"
+    r = d << pg.bbox()
+    r.properties[1] = "foo"
+    d.write_gds(fname)
+    d2 = pg.import_gds(fname)
+    assert d2.polygons[0].properties == d.polygons[0].properties
+    assert d2.references[0].properties == r.properties


### PR DESCRIPTION
Preserve Polygon.properties and DeviceReference.properties when saving and loading.

See
```python 
import os
import tempfile
fname = os.path.join(tempfile.mkdtemp(), 'properties.gds')
d = phidl.geometry.bbox()
d.polygons[0].properties[1] = 'yolo'
r = d << phidl.geometry.bbox()
r.properties[1] = "foo"
d.write_gds(fname)
d2 = phidl.geometry.import_gds(fname)
assert d2.polygons[0].properties == d.polygons[0].properties
assert d2.references[0].properties == r.properties
```