### PR TITLE
Fix a bug in boolean 'or' to always merge polys

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -591,7 +591,7 @@ def boolean(  # noqa: C901
         )
 
     # Check for trivial solutions
-    if (len(A_polys) == 0) or (len(B_polys) == 0):
+    if ((len(A_polys) == 0) or (len(B_polys) == 0)) and (operation != 'or'):
         if operation == "not":
             if len(A_polys) == 0:
                 p = None
@@ -599,13 +599,15 @@ def boolean(  # noqa: C901
                 p = A_polys
         elif operation == "and":
             p = None
-        elif (operation == "or") or (operation == "xor"):
+        elif operation == "xor":
             if (len(A_polys) == 0) and (len(B_polys) == 0):
                 p = None
             elif len(A_polys) == 0:
                 p = B_polys
             elif len(B_polys) == 0:
                 p = A_polys
+    elif (len(A_polys) == 0) and (len(B_polys) == 0) and (operation == 'or'):
+        p = None
     else:
         # If no trivial solutions, run boolean operation either in parallel or
         # straight


### PR DESCRIPTION
Suggestion to make boolean `'or'` merge all shapes within one Device, even if the second Device is `None` (or other way around).

Similar behavior to a `gdspy.boolean(multi_path, None, "or", max_points=0)` where 'multi_path' is a `gdspy.Path` with multiple elements.

For the trivial solutions to remain complete, a new `elif` case needs to be added for `(len(A_polys) == 0) and (len(B_polys) == 0) and (operation == 'or')` as `operation == 'or'` was moved out of the first case.