### PR TITLE
Make object arrays to prevent ValueError in numpy 1.24

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
   pytest:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -4984,8 +4984,8 @@ def optimal_step(
         # a wire from a width of 'W' to a width of 'a'
         # eta takes value 0 to pi
 
-        W = np.complex(W)
-        a = np.complex(a)
+        W = np.array(W, dtype=complex)
+        a = np.array(a, dtype=complex)
 
         gamma = (a * a + W * W) / (a * a - W * W)
 

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1391,8 +1391,8 @@ def _boolean_polygons_parallel(
 
     """
     # Build bounding boxes
-    polygons_A = np.asarray(polygons_A)
-    polygons_B = np.asarray(polygons_B)
+    polygons_A = np.asarray(polygons_A, dtype=object)
+    polygons_B = np.asarray(polygons_B, dtype=object)
     bboxes_A = _polygons_to_bboxes(polygons_A)
     bboxes_B = _polygons_to_bboxes(polygons_B)
 


### PR DESCRIPTION
See release notes:
https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations

> Ragged array creation will now always raise a `ValueError` unless `dtype=object` is passed. This includes very deeply nested sequences.
> ([gh-22004](https://github.com/numpy/numpy/pull/22004))

Currently, with numpy 1.24.1 I am getting:
```
2023-01-05T19:03:38.4295117Z     p = pg._boolean_polygons_parallel(
2023-01-05T19:03:38.4295422Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-01-05T19:03:38.4295597Z 
2023-01-05T19:03:38.4295891Z polygons_A = [array([[  96.493244, -119.142818],
2023-01-05T19:03:38.4296237Z        [  96.493244, -110.586912],
2023-01-05T19:03:38.4296536Z        [  93.473899, -107.567567],
2023-01-05T19:03:38.4296781Z        [  92...21622],
2023-01-05T19:03:38.4297060Z        [ 119.722972, -121.621622],
2023-01-05T19:03:38.4297498Z        [ 119.722297, -122.162163],
2023-01-05T19:03:38.4297832Z        [ 123.520271, -122.162163]]), ...]
2023-01-05T19:03:38.4298185Z polygons_B = [array([[ 37.16216216, -23.64864865],
2023-01-05T19:03:38.4298548Z        [ 37.16216216, -30.40540541],
2023-01-05T19:03:38.4298859Z        [ 30.40540541, -30.40540541],
2023-01-05T19:03:38.4299098Z       ...,
2023-01-05T19:03:38.4299367Z        [ 70.94594595, -30.40540541],
2023-01-05T19:03:38.4299693Z        [ 64.18918919, -30.40540541],
2023-01-05T19:03:38.4300015Z        [ 64.18918919, -23.64864865]]), ...]
2023-01-05T19:03:38.4300414Z num_divisions = [10, 10], operation = 'xor', precision = 1e-06
2023-01-05T19:03:38.4300580Z 
2023-01-05T19:03:38.4300834Z     def _boolean_polygons_parallel(polygons_A, polygons_B,
2023-01-05T19:03:38.4301157Z                                    num_divisions = [10, 10],
2023-01-05T19:03:38.4301469Z                                    operation = 'and',
2023-01-05T19:03:38.4301790Z                                    precision = 1e-4):
2023-01-05T19:03:38.4302114Z         """ Performs the boolean function on a list of subsections of the original
2023-01-05T19:03:38.4302422Z         geometry
2023-01-05T19:03:38.4302599Z     
2023-01-05T19:03:38.4302802Z         Parameters
2023-01-05T19:03:38.4303038Z         ----------
2023-01-05T19:03:38.4303308Z         polygons_A : PolygonSet or list of polygons
2023-01-05T19:03:38.4303602Z             Set or list of polygons to be booleaned.
2023-01-05T19:03:38.4303913Z         polygons_B : PolygonSet or list of polygons
2023-01-05T19:03:38.4304207Z             Set or list of polygons to be booleaned.
2023-01-05T19:03:38.4304561Z         num_divisions : array-like[2] of int
2023-01-05T19:03:38.4304883Z             The number of divisions with which the geometry is divided into
2023-01-05T19:03:38.4305262Z             multiple rectangular regions. This allows for each region to be
2023-01-05T19:03:38.4305631Z             processed sequentially, which is more computationally efficient.
2023-01-05T19:03:38.4306083Z         operation : {'not', 'and', 'or', 'xor', 'A-B', 'B-A', 'A+B'}
2023-01-05T19:03:38.4306390Z             Boolean operation to perform.
2023-01-05T19:03:38.4306648Z         precision : float
2023-01-05T19:03:38.4307023Z             Desired precision for rounding vertex coordinates.
2023-01-05T19:03:38.4307268Z     
2023-01-05T19:03:38.4307463Z         Returns
2023-01-05T19:03:38.4307692Z         -------
2023-01-05T19:03:38.4307947Z         boolean_polygons : list of polygons
2023-01-05T19:03:38.4308253Z             All the booleaned polygons from each of the subsections
2023-01-05T19:03:38.4308521Z     
2023-01-05T19:03:38.4308685Z         """
2023-01-05T19:03:38.4308902Z         # Build bounding boxes
2023-01-05T19:03:38.4309156Z >       polygons_A = np.asarray(polygons_A)
2023-01-05T19:03:38.4309659Z E       ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (16,) + inhomogeneous part.
```