### PR TITLE
Small Typo in the geometry.grid function, np.object instead of np.object_

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
   pytest:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1391,8 +1391,8 @@ def _boolean_polygons_parallel(
 
     """
     # Build bounding boxes
-    polygons_A = np.asarray(polygons_A)
-    polygons_B = np.asarray(polygons_B)
+    polygons_A = np.asarray(polygons_A, dtype=object)
+    polygons_B = np.asarray(polygons_B, dtype=object)
     bboxes_A = _polygons_to_bboxes(polygons_A)
     bboxes_B = _polygons_to_bboxes(polygons_B)
 
@@ -4984,8 +4984,8 @@ def optimal_step(
         # a wire from a width of 'W' to a width of 'a'
         # eta takes value 0 to pi
 
-        W = np.complex(W)
-        a = np.complex(a)
+        W = np.array(W, dtype=complex)
+        a = np.array(a, dtype=complex)
 
         gamma = (a * a + W * W) / (a * a - W * W)
 

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3375,7 +3375,7 @@ def grid(
 
     # Create a blank Device and reference all the Devices in it
     D = Device("grid")
-    ref_array = np.empty(device_array.shape, dtype=np.object)
+    ref_array = np.empty(device_array.shape, dtype=np.object_)
     dummy = Device()
     for idx, d in np.ndenumerate(device_array):
         if d is not None:

--- a/phidl/path.py
+++ b/phidl/path.py
@@ -362,7 +362,7 @@ def smooth(
     encroachment = np.concatenate([[0], d]) + np.concatenate([d, [0]])
     if np.any(encroachment > ds):
         raise ValueError(
-            "[PHIDL] smooth(): Not enough distance between points to to fit curves.  Try reducing the radius or spacing the points out farther"
+            "[PHIDL] smooth(): Not enough distance between points to fit curves.  Try reducing the radius or spacing the points out farther"
         )
     p1 = points[1:-1, :] - normals[:-1, :] * d[:, np.newaxis]
 


### PR DESCRIPTION
The function is missing a underline after np.object_ (https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.object_)