### PR TITLE
Small Typo in the geometry.grid function, np.object instead of np.object_Np.object typo

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3375,7 +3375,7 @@ def grid(
 
     # Create a blank Device and reference all the Devices in it
     D = Device("grid")
-    ref_array = np.empty(device_array.shape, dtype=np.object)
+    ref_array = np.empty(device_array.shape, dtype=np.object_)
     dummy = Device()
     for idx, d in np.ndenumerate(device_array):
         if d is not None:

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3375,7 +3375,7 @@ def grid(
 
     # Create a blank Device and reference all the Devices in it
     D = Device("grid")
-    ref_array = np.empty(device_array.shape, dtype=np.object_)
+    ref_array = np.empty(device_array.shape, dtype=object)
     dummy = Device()
     for idx, d in np.ndenumerate(device_array):
         if d is not None:


### PR DESCRIPTION
numpy has only a np.object_ type.

In the function the dtype is missing a underline after np.object_ (https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.object_)