### PR TITLE
1.6.3

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
   pytest:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+
+## 1.6.3 (Feb 9, 2023)
+
+### Bugfixes
+- Fixed error in `pg.euler()` and `pp.smooth()` for edge case of nearly-colinear points
+- Specify certain numpy arrays as `object` to avoid numpy deprecation (thanks Bas Nijholt @basnijholt and Samuel Gyger @gyger)
+- Corrected docstring for `pg.union()` as it does not accept lists of Devices (improvement for future, thanks Samuel Gyger @gyger)
+
+
+
 ## 1.6.2 (July 25, 2022)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GDS scripting for Python that's intuitive, fast, and powerful.
 - [**Installation / requirements**](#installation--requirements)
 - [**Tutorial + examples**](https://phidl.readthedocs.io/en/latest/tutorials.html) (or [try an interactive notebook](https://mybinder.org/v2/gh/amccaugh/phidl/master?filepath=phidl_tutorial_example.ipynb))
 - [**Geometry library + function documentation**](https://phidl.readthedocs.io/en/latest/geometry_reference.html)
-- [Changelog](https://github.com/amccaugh/phidl/blob/master/CHANGELOG.md) (latest update 1.6.2 on July 25, 2022)
+- [Changelog](https://github.com/amccaugh/phidl/blob/master/CHANGELOG.md) (latest update 1.6.3 on Feb 9, 2023)
     - Huge new routing rewrite for `phidl.routing`, including automatic manhattan routing with custom cross-sections!  See [the routing documentation](https://phidl.readthedocs.io/en/latest/tutorials/routing.html) for details. Big thanks to Jeffrey Holzgrafe @jolzgrafe for this contribution
     - `Path`s can now be used to produce sharp angles, in addition to smooth bends. See [the Path documentation](https://phidl.readthedocs.io/en/latest/tutorials/waveguides.html#Sharp/angular-paths)
 

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -1272,6 +1272,12 @@ class Device(gdspy.Cell, _GeometryHelper):
                 """[PHIDL] add_array() was passed something that
             was not a Device object. """
             )
+
+        if np.size(spacing) != 2:
+            raise ValueError(
+                """[PHIDL] add_array() The spacing argument must
+            have exactly 2 elements, e.g. (150,80) """
+            )
         a = CellArray(
             device=device,
             columns=int(round(columns)),

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -10,13 +10,13 @@
 # Minor TODO
 # ==============================================================================
 # Add Group.get_polygons()
-    # Allow Boolean to use Groups
-    # Allow pg.union to use Groups
+# Allow Boolean to use Groups
+# Allow pg.union to use Groups
 # Add pp.delay_sine(distance = 10, length = 20, num_periods = 2)
 # Allow connect(overlap) to be a tuple (0, 0.7)
 # Possibly replace gdspy bezier (font rendering) with
 #   https://stackoverflow.com/a/12644499
-# 
+#
 
 # ==============================================================================
 # Documentation TODO

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -10,11 +10,14 @@
 # Minor TODO
 # ==============================================================================
 # Add Group.get_polygons()
-# Allow Boolean to use Groups
+    # Allow Boolean to use Groups
+    # Allow pg.union to use Groups
 # Add pp.delay_sine(distance = 10, length = 20, num_periods = 2)
 # Allow connect(overlap) to be a tuple (0, 0.7)
 # Possibly replace gdspy bezier (font rendering) with
 #   https://stackoverflow.com/a/12644499
+# 
+
 # ==============================================================================
 # Documentation TODO
 # ==============================================================================

--- a/phidl/device_layout.py
+++ b/phidl/device_layout.py
@@ -55,7 +55,7 @@ from phidl.constants import _CSS3_NAMES_TO_HEX
 
 gdspy.library.use_current_library = False
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 
 # ==============================================================================

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1391,8 +1391,8 @@ def _boolean_polygons_parallel(
 
     """
     # Build bounding boxes
-    polygons_A = np.asarray(polygons_A)
-    polygons_B = np.asarray(polygons_B)
+    polygons_A = np.asarray(polygons_A, dtype=object)
+    polygons_B = np.asarray(polygons_B, dtype=object)
     bboxes_A = _polygons_to_bboxes(polygons_A)
     bboxes_B = _polygons_to_bboxes(polygons_B)
 
@@ -4984,8 +4984,8 @@ def optimal_step(
         # a wire from a width of 'W' to a width of 'a'
         # eta takes value 0 to pi
 
-        W = np.complex(W)
-        a = np.complex(a)
+        W = np.array(W, dtype=complex)
+        a = np.array(a, dtype=complex)
 
         gamma = (a * a + W * W) / (a * a - W * W)
 

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3375,7 +3375,7 @@ def grid(
 
     # Create a blank Device and reference all the Devices in it
     D = Device("grid")
-    ref_array = np.empty(device_array.shape, dtype=np.object)
+    ref_array = np.empty(device_array.shape, dtype=object)
     dummy = Device()
     for idx, d in np.ndenumerate(device_array):
         if d is not None:

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -853,7 +853,7 @@ def union(D, by_layer=False, precision=1e-4, join_first=True, max_points=4000, l
 
     Parameters
     ----------
-    D : Device(/Reference) or list of Device(/Reference)
+    D : Device(/Reference)
         A Device containing polygons to perform a union on.
     by_Layer : bool
         If true, performs the union operation layer-wise so each layer can be

--- a/phidl/path.py
+++ b/phidl/path.py
@@ -131,12 +131,20 @@ def euler(radius=3, angle=90, p=1.0, use_eff=False, num_pts=720):
     num_pts = abs(int(num_pts * angle / 360))
     num_pts_euler = int(np.round(sp / (s0 / 2) * num_pts))
     num_pts_arc = num_pts - num_pts_euler
+    # Ensure a minimum of 2 points for each euler/arc section
+    if num_pts <= 2:
+        num_pts_euler = 0
+        num_pts_arc = 2 
 
-    xbend1, ybend1 = _fresnel(R0, sp, num_pts_euler)
-    xp, yp = xbend1[-1], ybend1[-1]
-
-    dx = xp - Rp * np.sin(p * alpha / 2)
-    dy = yp - Rp * (1 - np.cos(p * alpha / 2))
+    if num_pts_euler > 0:
+        xbend1, ybend1 = _fresnel(R0, sp, num_pts_euler)
+        xp, yp = xbend1[-1], ybend1[-1]
+        dx = xp - Rp * np.sin(p * alpha / 2)
+        dy = yp - Rp * (1 - np.cos(p * alpha / 2))
+    else:
+        xbend1 = ybend1 = np.asfarray([])
+        dx = 0
+        dy = 0
 
     s = np.linspace(sp, s0 / 2, num_pts_arc)
     xbend2 = Rp * np.sin((s - sp) / Rp + p * alpha / 2) + dx

--- a/phidl/path.py
+++ b/phidl/path.py
@@ -362,7 +362,7 @@ def smooth(
     encroachment = np.concatenate([[0], d]) + np.concatenate([d, [0]])
     if np.any(encroachment > ds):
         raise ValueError(
-            "[PHIDL] smooth(): Not enough distance between points to to fit curves.  Try reducing the radius or spacing the points out farther"
+            "[PHIDL] smooth(): Not enough distance between points to fit curves.  Try reducing the radius or spacing the points out farther"
         )
     p1 = points[1:-1, :] - normals[:-1, :] * d[:, np.newaxis]
 

--- a/phidl/path.py
+++ b/phidl/path.py
@@ -134,7 +134,7 @@ def euler(radius=3, angle=90, p=1.0, use_eff=False, num_pts=720):
     # Ensure a minimum of 2 points for each euler/arc section
     if num_pts <= 2:
         num_pts_euler = 0
-        num_pts_arc = 2 
+        num_pts_arc = 2
 
     if num_pts_euler > 0:
         xbend1, ybend1 = _fresnel(R0, sp, num_pts_euler)


### PR DESCRIPTION

## 1.6.3 (Feb 9, 2023)

### Bugfixes
- Fixed error in `pg.euler()` and `pp.smooth()` for edge case of nearly-colinear points
- Specify certain numpy arrays as `object` to avoid numpy deprecation (thanks Bas Nijholt @basnijholt and Samuel Gyger @gyger)
- Corrected docstring for `pg.union()` as it does not accept lists of Devices (improvement for future, thanks Samuel Gyger @gyger)
