### PR TITLE
pg.grid: move shape parameter reordering to allow for empty shape

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3336,6 +3336,7 @@ def grid(
     """
 
     device_array = np.asarray(device_list)
+    spacing = np.broadcast_to(spacing, 2)
     # Check arguments
     if device_array.ndim not in (1, 2):
         raise ValueError("[PHIDL] grid() The device_list needs to be 1D or 2D.")

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3316,8 +3316,8 @@ def grid(
         If True, guarantees elements are speparated with a fixed spacing
         between; if  False, elements are spaced evenly along a grid.
     shape : array-like[2]
-        x, y shape of the grid (see np.reshape). If no shape is given and the
-        list is 1D, the output is as if np.reshape were run with (1, -1).
+        x, y shape of the grid (as if np.reshape() were run with shape[::-1]). If no shape is given and the
+        list is 1D, the output is as if np.reshape were run with (-1, size of list).
     align_x : {'x', 'xmin', 'xmax'}
         Which edge to perform the x (column) alignment along
     align_y : {'y', 'ymin', 'ymax'}
@@ -3335,8 +3335,6 @@ def grid(
         A Device containing all the Devices in `device_list` in a grid.
     """
 
-    # Change (y,x) shape to (x,y) shape
-    shape = shape[::-1]
     device_array = np.asarray(device_list)
     # Check arguments
     if device_array.ndim not in (1, 2):
@@ -3351,12 +3349,15 @@ def grid(
     if (shape is None) and (device_array.ndim == 2):  # Already in desired shape
         shape = device_array.shape
     elif (shape is None) and (device_array.ndim == 1):
-        shape = (device_array.size, -1)
+        shape = (-1, device_array.size)
     elif 0 < shape[0] * shape[1] < device_array.size:
         raise ValueError(
             "[PHIDL] grid() The shape is too small for all the items in device_list"
         )
     else:
+        # Change (x,y) shape to (y,x) shape to follow default row, column format in np.reshape
+        shape = shape[::-1]
+        
         if np.min(shape) == -1:
             max_shape = np.max(shape)
             min_devices = int(np.ceil(device_array.size / max_shape) * max_shape)

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -3358,7 +3358,7 @@ def grid(
     else:
         # Change (x,y) shape to (y,x) shape to follow default row, column format in np.reshape
         shape = shape[::-1]
-        
+
         if np.min(shape) == -1:
             max_shape = np.max(shape)
             min_devices = int(np.ceil(device_array.size / max_shape) * max_shape)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -265,3 +265,24 @@ def test_packer():
     D = D_packed_list[0]
     h = D.hash_geometry(precision=1e-4)
     assert h == "d90e43693a5840bdc21eae85f56fdaa57fdb88b2"
+
+
+def test_grid():
+    device_list = []
+    for width1 in [1, 6, 9]:
+        for width2 in [1, 2, 4, 8]:
+            D = pg.taper(length=10, width1=width1, width2=width2, layer=0)
+            device_list.append(D)
+
+    D = pg.grid(
+        device_list,
+        spacing=(5, 1),
+        separation=True,
+        shape=(3, 4),
+        align_x="x",
+        align_y="y",
+        edge_x="x",
+        edge_y="ymax",
+    )
+    h = D.hash_geometry(precision=1e-4)
+    assert h == "9228ee40016e508f5589effd50056df633357de2"


### PR DESCRIPTION
fix grid to allow for empty shape parameter to recover old functionality that was removed in 5d91d44f1920dd64a9497a7ec34a851410696c0c.