### PR TITLE
20x speedup to _merge_nearby_floating_points

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -972,7 +972,8 @@ def _merge_nearby_floating_points(x, tol=1e-10):
     xargsort = np.argsort(x)
     xargunsort = np.argsort(xargsort)
     xsort = x[xargsort]
-    xsortthreshold = np.diff(xsort) < tol
+    dx = np.diff(xsort)
+    xsortthreshold = np.logical_and(dx < tol, dx > 0)
     xsortthresholdind = np.argwhere(xsortthreshold)
 
     # Merge nearby floating point values


### PR DESCRIPTION
`_merge_nearby_floating_points` is heavily used in `offset` and `union`. In 95% of cases, polygon coordinates that are `< tol` are also `== 0`, meaning they do not need to be changed. The change simply filters out `dx == 0`, resulting in 20x speedup.

This speedup matters because `_merge_nearby_floating_points` is often the limiting factor, even moreso than than the clipper logic. Attached cProfiles are from a typical die build. Based on how often I am using this function, 95% reduction in `_merge_nearby_floating_points` resulted in 40% reduction in my overall build time.

<img width="1540" alt="mergeFP-cProf-compare" src="https://github.com/amccaugh/phidl/assets/1455840/12c9574d-ccaa-48d9-8605-298c38cabe2a">

```bash
python -m cProfile -s tottime build_my_die.py > old_merge.txt
```

[new_merge.txt](https://github.com/amccaugh/phidl/files/14073588/new_merge.txt)
[old_merge.txt](https://github.com/amccaugh/phidl/files/14073589/old_merge.txt)
