### PR TITLE
Fix incorrect property keys when importing GDS files

### DIFF
--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -2225,6 +2225,7 @@ def import_gds(filename, cellname=None, flatten=False):
             temp_polygons = list(D.polygons)
             D.polygons = []
             for p in temp_polygons:
+                p.properties = _correct_properties(p.properties)
                 D.add_polygon(p)
 
         topdevice = c2dmap[topcell]
@@ -2239,7 +2240,7 @@ def import_gds(filename, cellname=None, flatten=False):
         return D
 
 
-def _correct_properties(properties: dict[int, str]) -> None:
+def _correct_properties(properties: dict[int, str]) -> dict[int, str]:
     """
     Corrects the properties dictionary of a loaded GDS element to handle the
     conversion of keys from signed to unsigned integers.
@@ -2255,16 +2256,19 @@ def _correct_properties(properties: dict[int, str]) -> None:
 
     Returns
     -------
-    None
-        The input dictionary is modified in place.
+    dict[int, str]
+        The input dictionary is modified in place but also returned for convenience.
     """
     to_del = []
+    to_add = {}
     for key, value in properties.items():
         if key < 0:
-            properties[key + 2**16] = value
+            to_add[key + 2**16] = value
             to_del.append(key)
     for key in to_del:
         del properties[key]
+    properties.update(to_add)
+    return properties
 
 
 def _translate_cell(c):

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy as python_copy
 import itertools
 import json

--- a/phidl/geometry.py
+++ b/phidl/geometry.py
@@ -2225,7 +2225,7 @@ def import_gds(filename, cellname=None, flatten=False):
             temp_polygons = list(D.polygons)
             D.polygons = []
             for p in temp_polygons:
-                p.properties = _correct_properties(p.properties)
+                _correct_properties(p.properties)
                 D.add_polygon(p)
 
         topdevice = c2dmap[topcell]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -292,7 +292,9 @@ def test_write_and_import_gds():
         spacing=[14, 7.5],
     )
     D.add_polygon([[3, 4, 5], [6.7, 8.9, 10.15]], layer=[7, 8])
-    D.add_polygon([[3, 4, 5], [1.7, 8.9, 10.15]], layer=[7, 9])
+    poly = D.add_polygon([[3, 4, 5], [1.7, 8.9, 10.15]], layer=[7, 9])
+    poly.properties[0] = "start"
+    poly.properties[2**16 - 1] = "end"  # max allowed key (2 byte unsigned int)
     precision = 1e-4
     unit = 1e-6
     h1 = D.hash_geometry(precision=precision)
@@ -300,6 +302,7 @@ def test_write_and_import_gds():
     Dimport = pg.import_gds("temp.gds", flatten=False)
     h2 = Dimport.hash_geometry(precision=precision)
     assert h1 == h2
+    assert Dimport.polygons[-1].properties == poly.properties
 
 
 def test_packer():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -280,7 +280,9 @@ def test_copy_deepcopy():
 
 def test_write_and_import_gds():
     D = Device()
-    D.add_ref(pg.rectangle(size=[1.5, 2.7], layer=[3, 2]))
+    ref = D.add_ref(pg.rectangle(size=[1.5, 2.7], layer=[3, 2]))
+    ref.properties[0] = "start"
+    ref.properties[2**16 - 1] = "end"  # max allowed key (2 byte unsigned int)
     D.add_ref(pg.rectangle(size=[0.8, 2.5], layer=[9, 7]))
     D.add_array(
         pg.rectangle(size=[1, 2], layer=[4, 66]), rows=3, columns=2, spacing=[14, 7.5]
@@ -303,6 +305,7 @@ def test_write_and_import_gds():
     h2 = Dimport.hash_geometry(precision=precision)
     assert h1 == h2
     assert Dimport.polygons[-1].properties == poly.properties
+    assert Dimport.references[0].properties == ref.properties
 
 
 def test_packer():


### PR DESCRIPTION
This pull request addresses an issue where property keys are incorrectly interpreted as signed integers when importing GDS files using the `import_gds` function in `phidl.geometry`. The issue is caused by a bug in the `gdspy` library (heitzmann/gdspy#240).

When saving properties using `gdspy`, the keys are directly written to the GDS file as unsigned 16-bit integers (2 bytes). However, when loading the GDS file, `gdspy` interprets the keys as signed integers, resulting in negative values for keys greater than 32767.

This leads to incorrect property keys in the loaded GDS elements when using `phidl.geometry.import_gds`.

To work around this issue, a new function `_correct_properties` has been added to `phidl.geometry`. This function corrects the properties dictionary of a loaded GDS element by converting the keys from the signed integer range to the original unsigned integer range.

The `import_gds` function has been modified to call `_correct_properties` on the properties of each loaded GDS element (`DeviceReference` and `CellArray`) before assigning them to the corresponding `phidl` objects.

The `_correct_properties` function modifies the input `properties` dictionary in place. For each key-value pair, if the key is negative, it adds 65536 (2**16) to the key to convert it back to the original unsigned integer value. The value is then stored under the new key, and the negative key is marked for deletion. Finally, the marked keys are deleted from the dictionary.

This fix ensures that the property keys are correctly imported when loading GDS files using `phidl.geometry.import_gds`. Users of `phidl` who rely on the `import_gds` function to import GDS files with properties will benefit from this fix, as it will prevent incorrect property keys in the loaded GDS elements.

- heitzmann/gdspy#240
